### PR TITLE
Improvements in GTranslate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+GoogleTranslate/out/

--- a/GoogleTranslate/gtranslate.py
+++ b/GoogleTranslate/gtranslate.py
@@ -172,40 +172,63 @@
 
 # This subroutine calls Google translate and extracts the translation from
 # the html request
-def translate(to_translate, to_language="auto", language="auto"):
+
+async def translate(to_translate, to_language="auto", language="auto"):
+    excepted=False
+    while True:
+        try:
+            result = await translate_internal(to_translate, to_language, language)
+            if excepted:
+                print("FUCK: Success")
+            return result
+        except:
+            if excepted:
+                print("FUCK: Exception Again")
+            else:
+                print("FUCK: Exception")
+            excepted = True
+
+async def translate_internal(to_translate, to_language="auto", language="auto"):
     to_translate=serialize_text(to_translate, language)
     # send request
-    r = requests.get("https://translate.google.com/m?sl=%s&tl=%s&q=%s&op=translate"% (language, to_language, to_translate.replace(" ", "+")))
-    # set markers that enclose the charset identifier
-    beforecharset='charset='
-    aftercharset='" http-equiv'
-    # extract charset
-    parsed1=r.text[r.text.find(beforecharset)+len(beforecharset):]
-    parsed2=parsed1[:parsed1.find(aftercharset)]
-    # Display warning when encoding mismatch
-    if(parsed2!=r.encoding):
-        print('\x1b[1;31;40m' + 'Warning: Potential Charset conflict' )
-        print(" Encoding as extracted by SELF    : "+parsed2)
-        print(" Encoding as detected by REQUESTS : "+r.encoding+ '\x1b[0m')
+    session_timeout = aiohttp.ClientTimeout(total=5)
+    async with aiohttp.ClientSession(trust_env=True, timeout=session_timeout) as session:
+        translate_url = "https://translate.google.com/m?sl=%s&tl=%s&q=%s&op=translate"% (language, to_language, to_translate.replace(" ", "+"))
+        async with session.get(translate_url) as r:
+            # r = requests.get("https://translate.google.com/m?sl=%s&tl=%s&q=%s&op=translate"% (language, to_language, to_translate.replace(" ", "+")))
+            # set markers that enclose the charset identifier
+            beforecharset='charset='
+            aftercharset='" http-equiv'
+            # extract charset
+            text = await r.text()
+            text_encoding = r.get_encoding()
+            parsed1=text[text.find(beforecharset)+len(beforecharset):]
+            parsed2=parsed1[:parsed1.find(aftercharset)]
+            # Display warning when encoding mismatch
+            if(parsed2!=text_encoding):
+                pass
+                print('\x1b[1;31;40m' + 'Warning: Potential Charset conflict' )
+                print(" Encoding as extracted by SELF    : "+parsed2)
+                print(" Encoding as detected by REQUESTS : "+text_encoding+ '\x1b[0m')
 
-    # Work around an AGE OLD Python bug in case of windows-874 encoding
-    # https://bugs.python.org/issue854511
-    if(r.encoding=='windows-874' and os.name=='posix'):
-        print('\x1b[1;31;40m' + "Alert: Working around age old Python bug (https://bugs.python.org/issue854511)\nOn Linux, charset windows-874 must be labeled as charset cp874"+'\x1b[0m')
-        r.encoding='cp874'
+            # Work around an AGE OLD Python bug in case of windows-874 encoding
+            # https://bugs.python.org/issue854511
+            if(text_encoding=='windows-874' and os.name=='posix'):
+                print('\x1b[1;31;40m' + "Alert: Working around age old Python bug (https://bugs.python.org/issue854511)\nOn Linux, charset windows-874 must be labeled as charset cp874"+'\x1b[0m')
+                text_encoding='cp874'
 
-    # convert html tags
-    text=html.unescape(r.text)
-    # set markers that enclose the wanted translation
-    before_trans = 'class="result-container">'
-    after_trans='</div>'
-    # extract translation and return it
-    parsed1=r.text[r.text.find(before_trans)+len(before_trans):]
-    parsed2=parsed1[:parsed1.find(after_trans)]
-    # fix parameter strings
-    parsed3 = re.sub('% ([ds])', r' %\1', parsed2)
-    parsed4 = re.sub('% ([\d]) \$ ([ds])', r' %\1$\2', parsed3).strip()
-    return deserialize_text(html.unescape(parsed4).replace("'", r"\'"))
+            # convert html tags
+            # text=html.unescape(r.text)
+            # set markers that enclose the wanted translation
+            before_trans = 'class="result-container">'
+            after_trans='</div>'
+            # extract translation and return it
+            parsed1=text[text.find(before_trans)+len(before_trans):]
+            parsed2=parsed1[:parsed1.find(after_trans)]
+            # fix parameter strings
+            parsed3 = re.sub('% ([ds])', r' %\1', parsed2)
+            parsed4 = re.sub('% ([\d]) \$ ([ds])', r' %\1$\2', parsed3).strip()
+            return deserialize_text(html.unescape(parsed4).replace("'", r"\'"))
 
 
 
@@ -224,6 +247,7 @@ import shutil
 from pathlib import Path
 import asyncio
 import urllib.parse
+import aiohttp
 
 # ask user for paramters, apply defaults
 INFILE = sys.argv[1]
@@ -232,7 +256,7 @@ OUTPUTlangs = sys.argv[3:]
 
 if not OUTPUTlangs:
     OUTPUTlangs = ["af","sq","am","ar","hy","az","eu","be","bn","bs","bg","ca","ceb","ny","zh-CN","co","hr","cs","da","nl","en","eo","et","tl","fi","fr","fy","gl","ka","de","el","gu","ht","ha","haw","iw","hi","hmn","hu","is","ig","id","ga","it","ja","jw","kn","kk","km","rw","ko","ku","ky","lo","la","lv","lt","lb","mk","mg","ms","ml","mt","mi","mr","mn","my","ne","no","or","ps","fa","pl","pt","pa","ro","ru","sm","gd","sr","st","sn","sd","si","sk","sl","so","es","su","sw","sv","tg","ta","tt","te","th","tr","tk","uk","ur","ug","uz","vi","cy","xh","yi","yo","zu"]
-
+    OUTPUTlangs.remove(INPUTLANGUAGE)
 if not INFILE:
     INFILE = "strings.xml"
 if not INPUTLANGUAGE:
@@ -286,19 +310,19 @@ async def perform_translate(OUTPUTLANGUAGE):
     #	for each translatable string call the translation subroutine
     #   and replace the string by its translation,
     #   descend into each string array
-        time.sleep(1)
+    #     time.sleep(1)
         isTranslatable=root[i].get('translatable')
         if(root[i].tag=='string') & (isTranslatable!='false'):
             # trasnalte text and fix any possible issues traslotor creates: messing up HTML tags, adding spaces between string formatting elements
             totranslate=root[i].text
             if(totranslate!=None):
-                root[i].text=translate(totranslate,OUTPUTLANGUAGE,INPUTLANGUAGE)
+                root[i].text=await translate(totranslate,OUTPUTLANGUAGE,INPUTLANGUAGE)
 
             # if string was broken down due to HTML tags, reassemble it
             if len(root[i]) != 0:
                 for element in range(len(root[i])):
-                    root[i][element].text = " " + translate(root[i][element].text, OUTPUTLANGUAGE, INPUTLANGUAGE)
-                    root[i][element].tail = " " + translate(root[i][element].tail, OUTPUTLANGUAGE, INPUTLANGUAGE)
+                    root[i][element].text = " " + await translate(root[i][element].text, OUTPUTLANGUAGE, INPUTLANGUAGE)
+                    root[i][element].tail = " " + await translate(root[i][element].tail, OUTPUTLANGUAGE, INPUTLANGUAGE)
 
         if(root[i].tag=='string-array'):
             for j in range(len(root[i])):
@@ -309,14 +333,13 @@ async def perform_translate(OUTPUTLANGUAGE):
                     # trasnalte text and fix any possible issues traslotor creates: messing up HTML tags, adding spaces between string formatting elements
                     totranslate=root[i][j].text
                     if(totranslate!=None):
-                        root[i][j].text=translate(totranslate,OUTPUTLANGUAGE,INPUTLANGUAGE)
+                        root[i][j].text=await translate(totranslate,OUTPUTLANGUAGE,INPUTLANGUAGE)
 
                     # if string was broken down due to HTML tags, reassemble it
                     if len(root[i][j]) != 0:
                         for element in range(len(root[i][j])):
-                            root[i][j][element].text = " " + translate(root[i][j][element].text, OUTPUTLANGUAGE, INPUTLANGUAGE)
-                            root[i][j][element].tail = " " + translate(root[i][j][element].tail, OUTPUTLANGUAGE, INPUTLANGUAGE)
-
+                            root[i][j][element].text = " " + await translate(root[i][j][element].text, OUTPUTLANGUAGE, INPUTLANGUAGE)
+                            root[i][j][element].tail = " " + await translate(root[i][j][element].tail, OUTPUTLANGUAGE, INPUTLANGUAGE)
     # write new xml file
     tree.write(OUTFILE, encoding='utf-8')
 
@@ -328,5 +351,5 @@ async def start_translate():
 
 loop = asyncio.new_event_loop()
 asyncio.set_event_loop(loop)
-result = loop.run_until_complete(start_translate())
+loop.run_until_complete(start_translate())
 print("done")

--- a/GoogleTranslate/gtranslate.py
+++ b/GoogleTranslate/gtranslate.py
@@ -4,9 +4,9 @@
 # This python skript extracts string resources, calls Google translate
 # and reassambles a new strings.xml as fitted for Android projects.
 
-# run via 
+# run via
 
-# PYTHONIOENCODING=utf8 python3 gtranslate.py  OR using pythong launcher 
+# PYTHONIOENCODING=utf8 python3 gtranslate.py  OR using pythong launcher
 # follow instructions
 
 # output format: values-XX folders with strings.xml inside
@@ -173,41 +173,39 @@
 # This subroutine calls Google translate and extracts the translation from
 # the html request
 def translate(to_translate, to_language="auto", language="auto"):
+    to_translate=serialize_text(to_translate, language)
     # send request
     r = requests.get("https://translate.google.com/m?sl=%s&tl=%s&q=%s&op=translate"% (language, to_language, to_translate.replace(" ", "+")))
-    if("notranslate" in r.text):
-        return(to_translate)
-    else:		
-        # set markers that enclose the charset identifier
-        beforecharset='charset='
-        aftercharset='" http-equiv'
-        # extract charset 
-        parsed1=r.text[r.text.find(beforecharset)+len(beforecharset):]
-        parsed2=parsed1[:parsed1.find(aftercharset)]
-        # Display warning when encoding mismatch 
-        if(parsed2!=r.encoding):
-            print('\x1b[1;31;40m' + 'Warning: Potential Charset conflict' )
-            print(" Encoding as extracted by SELF    : "+parsed2)
-            print(" Encoding as detected by REQUESTS : "+r.encoding+ '\x1b[0m')
-	    
-        # Work around an AGE OLD Python bug in case of windows-874 encoding
-        # https://bugs.python.org/issue854511
-        if(r.encoding=='windows-874' and os.name=='posix'):
-            print('\x1b[1;31;40m' + "Alert: Working around age old Python bug (https://bugs.python.org/issue854511)\nOn Linux, charset windows-874 must be labeled as charset cp874"+'\x1b[0m')
-            r.encoding='cp874'
-	    
-        # convert html tags  
-        text=html.unescape(r.text)    
-        # set markers that enclose the wanted translation
-        before_trans = 'class="result-container">'
-        after_trans='</div>'
-        # extract translation and return it
-        parsed1=r.text[r.text.find(before_trans)+len(before_trans):]
-        parsed2=parsed1[:parsed1.find(after_trans)]
-        # fix parameter strings
-        parsed3 = re.sub('% ([ds])', r' %\1', parsed2)
-        parsed4 = re.sub('% ([\d]) \$ ([ds])', r' %\1$\2', parsed3).strip()
-        return html.unescape(parsed4).replace("'", r"\'")
+    # set markers that enclose the charset identifier
+    beforecharset='charset='
+    aftercharset='" http-equiv'
+    # extract charset
+    parsed1=r.text[r.text.find(beforecharset)+len(beforecharset):]
+    parsed2=parsed1[:parsed1.find(aftercharset)]
+    # Display warning when encoding mismatch
+    if(parsed2!=r.encoding):
+        print('\x1b[1;31;40m' + 'Warning: Potential Charset conflict' )
+        print(" Encoding as extracted by SELF    : "+parsed2)
+        print(" Encoding as detected by REQUESTS : "+r.encoding+ '\x1b[0m')
+
+    # Work around an AGE OLD Python bug in case of windows-874 encoding
+    # https://bugs.python.org/issue854511
+    if(r.encoding=='windows-874' and os.name=='posix'):
+        print('\x1b[1;31;40m' + "Alert: Working around age old Python bug (https://bugs.python.org/issue854511)\nOn Linux, charset windows-874 must be labeled as charset cp874"+'\x1b[0m')
+        r.encoding='cp874'
+
+    # convert html tags
+    text=html.unescape(r.text)
+    # set markers that enclose the wanted translation
+    before_trans = 'class="result-container">'
+    after_trans='</div>'
+    # extract translation and return it
+    parsed1=r.text[r.text.find(before_trans)+len(before_trans):]
+    parsed2=parsed1[:parsed1.find(after_trans)]
+    # fix parameter strings
+    parsed3 = re.sub('% ([ds])', r' %\1', parsed2)
+    parsed4 = re.sub('% ([\d]) \$ ([ds])', r' %\1$\2', parsed3).strip()
+    return deserialize_text(html.unescape(parsed4).replace("'", r"\'"))
 
 
 
@@ -222,11 +220,19 @@ import sys
 from io import BytesIO
 import re
 import time
+import shutil
+from pathlib import Path
+import asyncio
+import urllib.parse
 
 # ask user for paramters, apply defaults
-INFILE = input("Enter input filename: [default: strings.xml]\n")
-INPUTLANGUAGE = input("\nEnter source language: [default: en]\n")
-OUTPUTlangs = input("\nEnter output language(s): (space separated) \n\n").split()
+INFILE = sys.argv[1]
+INPUTLANGUAGE = sys.argv[2]
+OUTPUTlangs = sys.argv[3:]
+
+if not OUTPUTlangs:
+    OUTPUTlangs = ["af","sq","am","ar","hy","az","eu","be","bn","bs","bg","ca","ceb","ny","zh-CN","co","hr","cs","da","nl","en","eo","et","tl","fi","fr","fy","gl","ka","de","el","gu","ht","ha","haw","iw","hi","hmn","hu","is","ig","id","ga","it","ja","jw","kn","kk","km","rw","ko","ku","ky","lo","la","lv","lt","lb","mk","mg","ms","ml","mt","mi","mr","mn","my","ne","no","or","ps","fa","pl","pt","pa","ro","ru","sm","gd","sr","st","sn","sd","si","sk","sl","so","es","su","sw","sv","tg","ta","tt","te","th","tr","tk","uk","ur","ug","uz","vi","cy","xh","yi","yo","zu"]
+
 if not INFILE:
     INFILE = "strings.xml"
 if not INPUTLANGUAGE:
@@ -234,33 +240,65 @@ if not INPUTLANGUAGE:
 
 print("=================================================\n\n")
 
-# repeat proccess for each of the lang 
-for OUTPUTLANGUAGE in OUTPUTlangs:
-    OUTFILE= "strings_"+OUTPUTLANGUAGE+".xml"
+OUTDIRECTORY = Path('out')
+if OUTDIRECTORY.exists():
+    shutil.rmtree("out")
+os.makedirs("out")
+
+def serialize_text(text, language):
+    tag_match_regex = re.compile('<.*?>')
+    text = re.sub(tag_match_regex, '', text)  # Remove all html tags from text (although there should be none, but still ensuring)
+
+    # text = text.replace("&", "and")
+    text = text.replace("\\n", "\n")    # Replace "\" "n" with next line character
+    text = text.replace("\\'", "'")     # Replace \' with '
+    text = text.replace("\\@", "@")     # Replace \@ with @
+    text = text.replace("\\?", "?")     # Replace \? with ?
+    text = text.replace("\\\"", "\"")   # Replace \" with "
+
+    text = urllib.parse.quote_plus(text) # Encode final string
+
+    return text
+
+def deserialize_text(text):
+    text = text.replace('\\ ', '\\').replace('\\ n ', '\\n').replace('\\n ', '\\n').replace('/ ', '/')
+
+    text = text.replace("\n", "\\n")    # Replace next line with \n
+    # text = text.replace("'", "\\'")     # Replace ' with \'
+    text = text.replace("@", "\\@")     # Replace @ with \@
+    text = text.replace("?", "\\?")     # Replace ? with \?
+    text = text.replace("\"", "\\\"")   # Replace " with \"
+
+    return text
+
+# repeat proccess for each of the lang
+async def perform_translate(OUTPUTLANGUAGE):
+    os.makedirs("out/values-{OUTPUTLANGUAGE}".format(OUTPUTLANGUAGE = OUTPUTLANGUAGE))
+    OUTFILE= "out/values-{OUTPUTLANGUAGE}/strings.xml".format(OUTPUTLANGUAGE = OUTPUTLANGUAGE)
     # read xml structure
     tree = ET.parse(INFILE)
     root = tree.getroot()
 
     print(OUTPUTLANGUAGE + "...\n")
 
-    # cycle through elements 
+    # cycle through elements
     for i in range(len(root)):
     #	for each translatable string call the translation subroutine
     #   and replace the string by its translation,
-    #   descend into each string array  
+    #   descend into each string array
         time.sleep(1)
         isTranslatable=root[i].get('translatable')
         if(root[i].tag=='string') & (isTranslatable!='false'):
             # trasnalte text and fix any possible issues traslotor creates: messing up HTML tags, adding spaces between string formatting elements
             totranslate=root[i].text
             if(totranslate!=None):
-                root[i].text=translate(totranslate,OUTPUTLANGUAGE,INPUTLANGUAGE).replace('\\ ', '\\').replace('\\ n ', '\\n').replace('\\n ', '\\n').replace('/ ', '/')
+                root[i].text=translate(totranslate,OUTPUTLANGUAGE,INPUTLANGUAGE)
 
             # if string was broken down due to HTML tags, reassemble it
             if len(root[i]) != 0:
                 for element in range(len(root[i])):
-                    root[i][element].text = " " + translate(root[i][element].text, OUTPUTLANGUAGE, INPUTLANGUAGE).replace('\\ ', '\\').replace('\\ n ', '\\n').replace('\\n ', '\\n').replace('/ ', '/')
-                    root[i][element].tail = " " + translate(root[i][element].tail, OUTPUTLANGUAGE, INPUTLANGUAGE).replace('\\ ', '\\').replace('\\ n ', '\\n').replace('\\n ', '\\n').replace('/ ', '/')
+                    root[i][element].text = " " + translate(root[i][element].text, OUTPUTLANGUAGE, INPUTLANGUAGE)
+                    root[i][element].tail = " " + translate(root[i][element].tail, OUTPUTLANGUAGE, INPUTLANGUAGE)
 
         if(root[i].tag=='string-array'):
             for j in range(len(root[i])):
@@ -271,14 +309,24 @@ for OUTPUTLANGUAGE in OUTPUTlangs:
                     # trasnalte text and fix any possible issues traslotor creates: messing up HTML tags, adding spaces between string formatting elements
                     totranslate=root[i][j].text
                     if(totranslate!=None):
-                        root[i][j].text=translate(totranslate,OUTPUTLANGUAGE,INPUTLANGUAGE).replace('\\ ', '\\').replace('\\ n ', '\\n').replace('\\n ', '\\n').replace('/ ', '/')
+                        root[i][j].text=translate(totranslate,OUTPUTLANGUAGE,INPUTLANGUAGE)
 
                     # if string was broken down due to HTML tags, reassemble it
                     if len(root[i][j]) != 0:
                         for element in range(len(root[i][j])):
-                            root[i][j][element].text = " " + translate(root[i][j][element].text, OUTPUTLANGUAGE, INPUTLANGUAGE).replace('\\ ', '\\').replace('\\ n ', '\\n').replace('\\n ', '\\n').replace('/ ', '/')
-                            root[i][j][element].tail = " " + translate(root[i][j][element].tail, OUTPUTLANGUAGE, INPUTLANGUAGE).replace('\\ ', '\\').replace('\\ n ', '\\n').replace('\\n ', '\\n').replace('/ ', '/')
+                            root[i][j][element].text = " " + translate(root[i][j][element].text, OUTPUTLANGUAGE, INPUTLANGUAGE)
+                            root[i][j][element].tail = " " + translate(root[i][j][element].tail, OUTPUTLANGUAGE, INPUTLANGUAGE)
 
     # write new xml file
     tree.write(OUTFILE, encoding='utf-8')
 
+async def start_translate():
+    coroutines = []
+    for OUTPUTLANGUAGE in OUTPUTlangs:
+        coroutines.append(perform_translate(OUTPUTLANGUAGE))
+    await asyncio.gather(*coroutines)
+
+loop = asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
+result = loop.run_until_complete(start_translate())
+print("done")

--- a/GoogleTranslate/strings.xml
+++ b/GoogleTranslate/strings.xml
@@ -1,15 +1,17 @@
 <resources>
-  <string name="webadress">https://asrt.gluege.boerde.de</string>
-  <string name="simple_text">Search</string> 
-  <string name="includes_html_tags">Hello <b>World</b> !</string>
-  <string name="includes_paragraphs"
-    >Hello <b>World</b> !
-    \nThis is some test message
-    \n\nEven with double return!
-  </string>
-  <string-array name="search_title"> 
-		<item>What can I search for?</item> 
-		<item>Do I have to have an <i>account to search</i> and view information?</item> 
-		<item>How do I search for products shown in a design?</item> 
-	</string-array>
+    <string name="amp_quotes_and_next_line">• Enter number &amp; query.\n• Use \'Submit\' button to submit.</string>
+    <string name="next_line">Hi\nhow are you?</string>
+    <string name="webadress">https://asrt.gluege.boerde.de</string>
+    <string name="simple_text">Search</string>
+    <string name="includes_html_tags">Hello <b>World</b> !</string>
+    <string name="includes_paragraphs">
+        Hello <b>World</b> !
+        \nThis is some test message
+        \n\nEven with double return!
+    </string>
+    <string-array name="search_title">
+        <item>What can I search for?</item>
+        <item>Do I have to have an <i>account to search</i> and view information?</item>
+        <item>How do I search for products shown in a design?</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
1. Resolved Bug: https://github.com/Ra-Na/GTranslate-strings-xml/issues/36 (Check https://github.com/Ra-Na/GTranslate-strings-xml/issues/36#issuecomment-849490088)
2. Add: Take source file, input language, output languages as command line input (translate to all languages if output languages not specified)
```
python3 ./gtranslate.py string.xml en hi ru fr
```
3. Fixed incorrectly formatted strings, see `serialize_text` and `deserialize_text`
4. Add async translation generation for faster output. (Also, retry when request fails)
5. Add: Sample string `amp_quotes_and_next_line`, `next_line`.
6. Add .gitignore

Testing:
I have a strings.xml with 112 lines. I translated it to 108 languages using these changes.
Total translations: 12096
Time taken: About 2 mins